### PR TITLE
fix(instance): harden unix lock file opening

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5424,6 +5424,7 @@ dependencies = [
  "gtk",
  "iced",
  "image",
+ "libc",
  "log",
  "objc2 0.6.4",
  "objc2-app-kit 0.3.2",

--- a/crates/versi/Cargo.toml
+++ b/crates/versi/Cargo.toml
@@ -39,6 +39,9 @@ simplelog.workspace = true
 thiserror.workspace = true
 rfd = "0.17.2"
 
+[target.'cfg(unix)'.dependencies]
+libc = "0.2"
+
 [target.'cfg(target_os = "linux")'.dependencies]
 gtk = "0.18.2"
 zbus = { version = "5.16.0", default-features = false, features = ["blocking-api"] }

--- a/crates/versi/src/single_instance.rs
+++ b/crates/versi/src/single_instance.rs
@@ -94,7 +94,9 @@ mod windows_impl {
 #[cfg(not(windows))]
 mod other_impl {
     use std::fs::{File, OpenOptions};
-    use std::io::{Seek, SeekFrom, Write};
+    use std::io::{Error, ErrorKind, Seek, SeekFrom, Write};
+    #[cfg(unix)]
+    use std::os::unix::fs::{MetadataExt, OpenOptionsExt};
     use std::path::{Path, PathBuf};
 
     use versi_platform::AppPaths;
@@ -118,15 +120,9 @@ mod other_impl {
         }
 
         pub(super) fn acquire_at(path: &Path) -> Result<Self, super::AcquireError> {
-            let mut file = OpenOptions::new()
-                .create(true)
-                .read(true)
-                .write(true)
-                .truncate(false)
-                .open(path)
-                .map_err(|error| {
-                    super::AcquireError::io("failed to open instance lock file", error)
-                })?;
+            let mut file = open_lock_file(path).map_err(|error| {
+                super::AcquireError::io("failed to open instance lock file", error)
+            })?;
 
             match file.try_lock() {
                 Ok(()) => {}
@@ -150,6 +146,38 @@ mod other_impl {
 
             Ok(Self { _lock_file: file })
         }
+    }
+
+    fn open_lock_file(path: &Path) -> std::io::Result<File> {
+        let mut options = OpenOptions::new();
+        options.create(true).read(true).write(true).truncate(false);
+
+        #[cfg(unix)]
+        options.custom_flags(libc::O_NOFOLLOW).mode(0o600);
+
+        let file = options.open(path)?;
+        validate_lock_file(&file)?;
+        Ok(file)
+    }
+
+    fn validate_lock_file(file: &File) -> std::io::Result<()> {
+        let metadata = file.metadata()?;
+        if !metadata.file_type().is_file() {
+            return Err(Error::new(
+                ErrorKind::InvalidData,
+                "instance lock path is not a regular file",
+            ));
+        }
+
+        #[cfg(unix)]
+        if metadata.nlink() != 1 {
+            return Err(Error::new(
+                ErrorKind::InvalidData,
+                "instance lock file must not have multiple hard links",
+            ));
+        }
+
+        Ok(())
     }
 
     pub fn bring_existing_window_to_front() {}
@@ -186,6 +214,50 @@ mod tests {
             matches!(second, Err(super::AcquireError::AlreadyRunning)),
             "second acquire should fail with AlreadyRunning: {:?}",
             second.err(),
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn acquire_rejects_symlink_lock_without_clobbering_target() {
+        let dir = tempfile::tempdir().expect("should create temp dir");
+        let lock_path = dir.path().join("instance.lock");
+        let target_path = dir.path().join("target");
+        std::fs::write(&target_path, "keep me").expect("should write target");
+        std::os::unix::fs::symlink(&target_path, &lock_path).expect("should create symlink");
+
+        let instance = SingleInstance::acquire_at(&lock_path);
+
+        assert!(
+            instance.is_err(),
+            "acquire should reject a symlink lock path"
+        );
+        assert_eq!(
+            std::fs::read_to_string(&target_path).expect("should read target"),
+            "keep me",
+            "symlink target must not be truncated or overwritten"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn acquire_rejects_hard_linked_lock_without_clobbering_target() {
+        let dir = tempfile::tempdir().expect("should create temp dir");
+        let lock_path = dir.path().join("instance.lock");
+        let target_path = dir.path().join("target");
+        std::fs::write(&target_path, "keep me").expect("should write target");
+        std::fs::hard_link(&target_path, &lock_path).expect("should create hard link");
+
+        let instance = SingleInstance::acquire_at(&lock_path);
+
+        assert!(
+            instance.is_err(),
+            "acquire should reject a hard-linked lock path"
+        );
+        assert_eq!(
+            std::fs::read_to_string(&target_path).expect("should read target"),
+            "keep me",
+            "hard link target must not be truncated or overwritten"
         );
     }
 


### PR DESCRIPTION
### Motivation
- The non-Windows single-instance lock previously opened `instance.lock` without preventing symlink following or validating file type, allowing a local attacker with write access to the data directory to cause arbitrary file truncation when the app starts.

### Description
- Open the lock via a new `open_lock_file` helper that sets Unix `O_NOFOLLOW` and file mode `0o600` when available to avoid following symlinks and limit permissions.
- Validate the opened file is a regular file and, on Unix, verify it has a single hard link before truncating/writing the PID to avoid clobbering hard-linked targets.
- Replace the direct `OpenOptions::open` call with `open_lock_file` in the acquire flow and keep the exclusive lock behavior intact.
- Add Unix-only regression tests that ensure symlinked or hard-linked `instance.lock` paths are rejected and that target files are not overwritten, and add a `libc` dependency for Unix-only flags.

### Testing
- Ran `cargo fmt --all -- --check`, which succeeded.
- Verified diffs and formatting with `git diff --check` and committed the changes locally without whitespace errors.
- Attempted `cargo test -p versi single_instance -- --nocapture` and `cargo test --workspace`, but the test/build run is blocked in this environment due to a missing system dependency (`glib-2.0` / `pkg-config`), so unit tests could not be executed here.
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` was attempted but also blocked by the same missing system dependency.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a289cd1342483218f1109000fca0e7c)