### PR TITLE
fix(settings): prevent stale debounced saves

### DIFF
--- a/crates/versi/src/app/settings_save.rs
+++ b/crates/versi/src/app/settings_save.rs
@@ -1,40 +1,94 @@
-use std::sync::{OnceLock, mpsc};
+use std::sync::{
+    Arc, Mutex, OnceLock,
+    atomic::{AtomicU64, Ordering},
+    mpsc,
+};
 use std::time::Duration;
 
 use crate::settings::AppSettings;
 
 const SETTINGS_SAVE_DEBOUNCE: Duration = Duration::from_millis(250);
 
-pub(super) fn enqueue_settings_save(settings: AppSettings) {
-    let _ = settings_save_sender().send(settings);
+struct QueuedSettingsSave {
+    settings: AppSettings,
+    generation: u64,
 }
 
-fn settings_save_sender() -> &'static mpsc::Sender<AppSettings> {
-    static SETTINGS_SAVER: OnceLock<mpsc::Sender<AppSettings>> = OnceLock::new();
+struct SettingsSaveState {
+    generation: AtomicU64,
+    write_lock: Mutex<()>,
+}
+
+struct SettingsSaveCoordinator {
+    sender: mpsc::Sender<QueuedSettingsSave>,
+    state: Arc<SettingsSaveState>,
+}
+
+pub(super) fn enqueue_settings_save(settings: AppSettings) {
+    let coordinator = settings_save_coordinator();
+    let queued = QueuedSettingsSave {
+        settings,
+        generation: coordinator.state.generation.load(Ordering::Acquire),
+    };
+    let _ = coordinator.sender.send(queued);
+}
+
+pub(super) fn save_settings_sync(settings: &AppSettings) -> Result<(), std::io::Error> {
+    let coordinator = settings_save_coordinator();
+    let _guard = coordinator
+        .state
+        .write_lock
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    let result = settings.save();
+    if result.is_ok() {
+        coordinator.state.generation.fetch_add(1, Ordering::AcqRel);
+    }
+    result
+}
+
+fn settings_save_coordinator() -> &'static SettingsSaveCoordinator {
+    static SETTINGS_SAVER: OnceLock<SettingsSaveCoordinator> = OnceLock::new();
 
     SETTINGS_SAVER.get_or_init(|| {
-        let (sender, receiver) = mpsc::channel::<AppSettings>();
+        let (sender, receiver) = mpsc::channel::<QueuedSettingsSave>();
+        let state = Arc::new(SettingsSaveState {
+            generation: AtomicU64::new(0),
+            write_lock: Mutex::new(()),
+        });
+        let worker_state = Arc::clone(&state);
         std::thread::spawn(move || {
             while let Ok(mut latest) = receiver.recv() {
                 loop {
                     match receiver.recv_timeout(SETTINGS_SAVE_DEBOUNCE) {
                         Ok(next) => latest = next,
                         Err(mpsc::RecvTimeoutError::Timeout) => {
-                            if let Err(error) = latest.save() {
-                                log::error!("Failed to save settings: {error}");
-                            }
+                            save_latest_if_current(&worker_state, &latest);
                             break;
                         }
                         Err(mpsc::RecvTimeoutError::Disconnected) => {
-                            if let Err(error) = latest.save() {
-                                log::error!("Failed to save settings: {error}");
-                            }
+                            save_latest_if_current(&worker_state, &latest);
                             return;
                         }
                     }
                 }
             }
         });
-        sender
+        SettingsSaveCoordinator { sender, state }
     })
+}
+
+fn save_latest_if_current(state: &SettingsSaveState, latest: &QueuedSettingsSave) {
+    let _guard = state
+        .write_lock
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+
+    if latest.generation != state.generation.load(Ordering::Acquire) {
+        return;
+    }
+
+    if let Err(error) = latest.settings.save() {
+        log::error!("Failed to save settings: {error}");
+    }
 }

--- a/crates/versi/src/app/update/settings.rs
+++ b/crates/versi/src/app/update/settings.rs
@@ -278,7 +278,7 @@ impl Versi {
     }
 
     pub(crate) fn save_settings_with_log_sync(&self) {
-        if let Err(e) = self.settings.save() {
+        if let Err(e) = super::super::settings_save::save_settings_sync(&self.settings) {
             log::error!("Failed to save settings: {e}");
         }
     }


### PR DESCRIPTION
### Motivation
- Debounced background saves could write an older `AppSettings` snapshot after a synchronous save, causing newer fields (for example window geometry) to be lost.

### Description
- Introduce a settings save coordinator that tags queued snapshots with a `generation` counter and holds a `write_lock` to serialize writes in `crates/versi/src/app/settings_save.rs`.
- Worker thread now skips writing a queued snapshot if its `generation` is stale compared to the coordinator, preventing out-of-order overwrites.
- Route synchronous saves through the coordinator via a new `save_settings_sync` helper that acquires the same `write_lock` and increments the `generation` on success, and update `crates/versi/src/app/update/settings.rs` to call it.
- Change the channel payload to include generation metadata so debounced snapshots carry their generation for comparison before writing.

### Testing
- Ran formatting checks with `cargo fmt --all` and `cargo fmt --all -- --check`, which succeeded.
- Attempted `cargo test --workspace`, but the run was blocked by a missing system dependency (`glib-2.0` / `pkg-config`) required by `glib-sys` in the environment.
- Attempted `cargo clippy --workspace --all-targets --all-features -- -D warnings`, but the run was similarly blocked by the missing system `glib-2.0` dependency.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a289cd3527c8321a05c730779941995)